### PR TITLE
mistake in skip command 

### DIFF
--- a/music_cog.py
+++ b/music_cog.py
@@ -110,9 +110,7 @@ class music_cog(commands.Cog):
     @commands.command(name="skip", aliases=["s"], help="Skips the current song being played")
     async def skip(self, ctx):
         if self.vc != None and self.vc:
-            self.vc.stop()
-            #try to play next in the queue if it exists
-            await self.play_music(ctx)
+            self.vc.stop()         
 
 
     @commands.command(name="queue", aliases=["q"], help="Displays the current songs in queue")


### PR DESCRIPTION
the vc.stop() will stop the audio, so it will call play_next method
 ( because of FFmpegPCMAudio "after" arugment that calls play_next)
 So you dont need to call the play_music method
This would give an error(ClientException("Already playing audio.")), because the play_next method is already playing the music